### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,17 +6,17 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-BitLib	                KEYWORD1
+BitLib	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-getBitIndex	            KEYWORD2
-getBitsIndex2DecInt	    KEYWORD2
+getBitIndex	KEYWORD2
+getBitsIndex2DecInt	KEYWORD2
 getBitsIndex2DecChar	KEYWORD2
-setBitIndex             KEYWORD2
-setBitsIndex            KEYWORD2
-maxSizeBitsChar         KEYWORD2
-maxSizeBitsInt          KEYWORD2
-countBits               KEYWORD2
+setBitIndex	KEYWORD2
+setBitsIndex	KEYWORD2
+maxSizeBitsChar	KEYWORD2
+maxSizeBitsInt	KEYWORD2
+countBits	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab, the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords